### PR TITLE
Fix CSS path in hooks

### DIFF
--- a/branded_lms/hooks.py
+++ b/branded_lms/hooks.py
@@ -6,7 +6,8 @@ app_email = "info@yourcompany.com"
 app_license = "MIT"
 
 # Includes in <head>
-app_include_css = "/assets/branded_lms/css/custom.css"
+# Use the built CSS bundle generated via build.json
+app_include_css = "/assets/branded_lms/css/branded_lms.css"
 app_include_js = "/assets/branded_lms/js/branding.js"
 
 # Fixtures (include all custom DocTypes, roles, permissions)


### PR DESCRIPTION
## Summary
- use the built `branded_lms.css` instead of the missing `custom.css`

## Testing
- `python -m compileall -q branded_lms/hooks.py`


------
https://chatgpt.com/codex/tasks/task_e_687624ccb154832c940a23324bc134e9