### PR TITLE
Fix JS asset path

### DIFF
--- a/branded_lms/hooks.py
+++ b/branded_lms/hooks.py
@@ -8,7 +8,8 @@ app_license = "MIT"
 # Includes in <head>
 # Use the built CSS bundle generated via build.json
 app_include_css = "/assets/branded_lms/css/branded_lms.css"
-app_include_js = "/assets/branded_lms/js/branding.js"
+# Use the JavaScript bundle defined in build.json
+app_include_js = "/assets/branded_lms/js/branded_lms.js"
 
 # Fixtures (include all custom DocTypes, roles, permissions)
 fixtures = [


### PR DESCRIPTION
## Summary
- fix wrong JS asset path in hooks

## Testing
- `pre-commit` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68762f0c4448832cba842d43b6cac9f0